### PR TITLE
fix: removed unused simp

### DIFF
--- a/lean-circuit/LeanCircuit/SemanticEquivalence.lean
+++ b/lean-circuit/LeanCircuit/SemanticEquivalence.lean
@@ -97,7 +97,6 @@ lemma MerkleTreeInclusionProof_looped (Leaf: F) (PathIndices: Vector F D) (Sibli
       merkle_tree_recover_rounds Leaf PathIndices Siblings k := by
     unfold Semaphore.MerkleTreeInclusionProof_20_20
     simp [merkle_tree_recover_rounds]
-    simp [merkle_tree_recover_rounds]
     rw [←Vector.ofFn_get (v := PathIndices)]
     rw [←Vector.ofFn_get (v := Siblings)]
     rfl


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
Removed double use of `simp [merkle_tree_recover_rounds]` because not needed

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->

# Checklist

- [x] Code is formatted akin to the other code in the repo.
- [x] Documentation has been updated if necessary.
