### PR TITLE
fix: added timeout workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 600
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,5 @@ jobs:
     - name: Build lean project
       run: |
         cd lean-circuit
+        ~/.elan/bin/lake exe cache get
         ~/.elan/bin/lake build


### PR DESCRIPTION
# Summary

<!-- What is this PR about? -->
Github CI timeouts at 360min (default). Changed default setting to 600min. Added lake exe cache get.

# Details

<!-- What do you want the reviewers to focus on? Anything important that they should know? -->
`lake build` command takes around 6 hours to build `mathlib4` which means it is prone to hit the timeout limit of 360min if there is no cache available. Increased the timeout to 600min.

# Checklist

- [x] Code is formatted akin to the other code in the repo.
- [x] Documentation has been updated if necessary.
